### PR TITLE
Fix jump bug

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 .hypothesis
+DEBUG.md
+tmp.py
+__pycache__

--- a/code_data/code_data_test.py
+++ b/code_data/code_data_test.py
@@ -73,7 +73,8 @@ def f(x):
             % (("x = x or " + "-x" * 2500,) * 10),
             id="long jump",
         ),
-        pytest.param("""import json
+        pytest.param(
+            """import json
 
 def test_json():
     tmpdir = tempfile.mkdtemp()
@@ -111,7 +112,9 @@ def test_json():
 
 
     finally:
-        pass""", id="notebook.tests.test_config_manager minimal case")
+        pass""",
+            id="notebook.tests.test_config_manager minimal case",
+        ),
     ],
 )
 def test_examples(source):
@@ -128,14 +131,14 @@ def test_modules(subtests):
     # Keep a list of failures, so we can print the shortest at the end
     # list of (name, source) tuples
     failures: list[tuple[str, str]] = []
-    
+
     for name, source, code in module_codes():
         failures.append((name, source))
         with subtests.test(name):
             verify_code(code)
             # If we got here, then the verification succeeded, and we can remove from failures.
             failures.pop()
-    
+
     if failures:
         # sort failures by length of source
         name, source = sorted(failures, key=lambda failure: len(failure[1]))[0]
@@ -177,7 +180,7 @@ def module_codes() -> Iterable[tuple[str, str, CodeType]]:
             except SyntaxError:
                 continue
             if code:
-                source = loader.get_source(mi.name) #type: ignore
+                source = loader.get_source(mi.name)  # type: ignore
                 yield mi.name, source, code
 
 

--- a/code_data/code_data_test.py
+++ b/code_data/code_data_test.py
@@ -113,8 +113,75 @@ def test_json():
 
     finally:
         pass""",
+            # Tests for a relative jump which has extended args
             id="notebook.tests.test_config_manager minimal case",
         ),
+        pytest.param(
+            '''"""Build a project using PEP 517 hooks.
+"""
+import argparse
+import io
+import logging
+import os
+import shutil
+
+from .envbuild import BuildEnvironment
+from .wrappers import Pep517HookCaller
+from .dirtools import tempdir, mkdir_p
+from .compat import FileNotFoundError, toml_load
+
+log = logging.getLogger(__name__)
+
+
+def validate_system():
+    pass
+
+
+def load_system():
+    pass
+
+
+def compat_system():
+    pass
+
+
+def _do_build():
+    pass
+
+
+def build(system=None):
+    pass
+
+parser = argparse.ArgumentParser()
+parser.add_argument(
+    'source_dir',
+    help="A directory containing pyproject.toml",
+)
+parser.add_argument(
+    '--binary', '-b',
+    action='store_true',
+    default=False,
+)
+parser.add_argument(
+    '--source', '-s',
+    action='store_true',
+    default=False,
+)
+parser.add_argument(
+    '--out-dir', '-o',
+    help="Destination in which to save the builds relative to source dir",
+)
+
+
+def main(args):
+    pass
+
+
+
+if __name__ == '__main__':
+    main(parser.parse_args())
+''', id='pip._vendor.pep517.build minimal'
+        )
     ],
 )
 def test_examples(source):

--- a/code_data/code_data_test.py
+++ b/code_data/code_data_test.py
@@ -180,8 +180,9 @@ def main(args):
 
 if __name__ == '__main__':
     main(parser.parse_args())
-''', id='pip._vendor.pep517.build minimal'
-        )
+''',
+            id="pip._vendor.pep517.build minimal",
+        ),
     ],
 )
 def test_examples(source):

--- a/code_data/control_flow_graph.py
+++ b/code_data/control_flow_graph.py
@@ -98,7 +98,7 @@ def cfg_to_bytes(cfg: ControlFlowGraph) -> bytes:
                 arg_value = args[block_index, instruction_index]
                 n_instructions = instruction.n_args_override or instrsize(arg_value)
                 current_instruction_offset += n_instructions
-                    
+
                 if isinstance(arg, Jump):
                     target_instruction_offset = block_index_to_instruction_offset[
                         arg.target
@@ -112,10 +112,12 @@ def cfg_to_bytes(cfg: ControlFlowGraph) -> bytes:
                         new_arg_value = multiplier * target_instruction_offset
                     # If we aren't overriding and the new size of instructions is not the same
                     # as the old, mark this as updated, so we re-calculate block positions!
-                    if not instruction.n_args_override and n_instructions != instrsize(new_arg_value):
+                    if not instruction.n_args_override and n_instructions != instrsize(
+                        new_arg_value
+                    ):
                         changed_instruction_lengths = True
                     args[block_index, instruction_index] = new_arg_value
-    
+
     # Finally go assemble the bytes
     bytes_ = b""
     for block_index, block in cfg.items():

--- a/code_data/control_flow_graph.py
+++ b/code_data/control_flow_graph.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 import dis
 import sys
 from dataclasses import dataclass, field
-from typing import List, Optional, Union, Dict
+from typing import Dict, List, Optional, Union
 
 from .dataclass_hide_default import DataclassHideDefault
 from .instruction_data import InstructionData, instrsize, instructions_from_bytes

--- a/code_data/dataclass_hide_default.py
+++ b/code_data/dataclass_hide_default.py
@@ -9,6 +9,9 @@ class DataclassHideDefault:
 
     This lets us control the rich output for dataclasses, since it looks
     at the `repr` of each field to know whether to display it.
+
+    TODO: Just implement rich repr to do this more obviously
+    https://rich.readthedocs.io/en/stable/pretty.html
     """
 
     def __getattribute__(self, __name: str) -> object:

--- a/code_data/instruction_data.py
+++ b/code_data/instruction_data.py
@@ -76,7 +76,12 @@ class InstructionData(DataclassHideDefault):
         n_args = len(args)
         # The number of args should be at least the minimum
         assert n_args >= min_n_args
-        n_args_override = None if n_args == min_n_args else n_args
+        # Store the number of args if this is a jump instruction
+        # This is needed to preserve isomporphic behavior. Otherwise
+        # there are cases where jump instructions could be different values
+        # (and have different number of args), but point to the same instruction
+        # offset.
+        n_args_override = n_args if jump_target_offset is not None else None
 
         return cls(
             offset=offset,


### PR DESCRIPTION
This PR fixes a jump bug, which emitted the wrong bytecode offset when there were extended instructions. It also changes the blocks to be a dictionary.

Closes https://github.com/metadsl/python-code-data/issues/13