### PR TITLE
Support negative jumps in 3.10

### DIFF
--- a/code_data/code_data_test.py
+++ b/code_data/code_data_test.py
@@ -183,6 +183,14 @@ if __name__ == '__main__':
 ''',
             id="pip._vendor.pep517.build minimal",
         ),
+        pytest.param(
+            """while not x < y < z:
+    pass""",
+            # Reduced from imagesize modeul
+            # https://bugs.python.org/issue46724
+            # negative opargs in Python 3.10
+            id="bpo-46724",
+        ),
     ],
 )
 def test_examples(source):
@@ -242,7 +250,6 @@ def module_codes() -> Iterable[tuple[str, str, CodeType]]:
         warnings.simplefilter("ignore")
         for mi in pkgutil.walk_packages(onerror=lambda _name: None):
             loader: Loader = mi.module_finder.find_module(mi.name)  # type: ignore
-            loader.__ne__
             try:
                 code = loader.get_code(mi.name)  # type: ignore
             except SyntaxError:

--- a/code_data/code_data_test.py
+++ b/code_data/code_data_test.py
@@ -186,7 +186,7 @@ if __name__ == '__main__':
         pytest.param(
             """while not x < y < z:
     pass""",
-            # Reduced from imagesize modeul
+            # Reduced from imagesize module
             # https://bugs.python.org/issue46724
             # negative opargs in Python 3.10
             id="bpo-46724",


### PR DESCRIPTION
Adds support for negative relative jump args introduced in Python 3.10.

Ports corresponding fix from dis
https://github.com/python/cpython/pull/31285