### PR TITLE
Special case arguments

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,7 +24,8 @@ jobs:
       # TODO: #48 Only install test requirements instead of all pinned in CI
       - run: pip install -e . -r requirements.test.txt
       - run: pytest -v code_data
-      - name: Push changes
+      - name: Commit and push failing example
+        if: failure()
         run: |
           git config --global user.name 'github-actions[bot]'
           git config --global user.email 'github-actions[bot]@users.noreply.github.com'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,6 +24,13 @@ jobs:
       # TODO: #48 Only install test requirements instead of all pinned in CI
       - run: pip install -e . -r requirements.test.txt
       - run: pytest -v code_data
+      - name: Push changes
+        run: |
+          git config --global user.name 'github-actions[bot]'
+          git config --global user.email 'github-actions[bot]@users.noreply.github.com'
+          git add code_data/test_minimized/
+          git commit -m "Add failing example from testing on Python ${{ matrix.py}}"
+          git push
   # Just test building the docs on read the docs, not on github actions
   #   docs:
   #     name: docs build

--- a/code_data/__init__.py
+++ b/code_data/__init__.py
@@ -48,8 +48,9 @@ class CodeData(DataclassHideDefault):
     # the first line number in the line table.
     first_line_number_override: Optional[int] = field(default=None)
 
-    # Additional names to include, which do not appear in any instructions
-    additional_names: tuple[str, ...] = field(default=())
+    # Additional names to include, which do not appear in any instructions,
+    # Mapping of index in the names list to the name
+    additional_names: dict[int, str] = field(default_factory=dict)
 
     # number of arguments (not including keyword only arguments, * or ** args)
     argcount: int = field(default=0)
@@ -135,8 +136,9 @@ def from_code_data(code_data: CodeData) -> CodeType:
     """
     consts = tuple(map(from_code_constant, code_data.consts))
     flags = from_flags_data(code_data.flags)
-    code, line_mapping, names = blocks_to_bytes(code_data.blocks)
-    names += code_data.additional_names
+    code, line_mapping, names = blocks_to_bytes(
+        code_data.blocks, code_data.additional_names
+    )
 
     line_mapping.update(code_data.additional_line_mapping)
     first_line_no = line_mapping.trim_first_line(code_data.first_line_number_override)

--- a/code_data/__init__.py
+++ b/code_data/__init__.py
@@ -165,7 +165,7 @@ def from_code_data(code_data: CodeData) -> CodeType:
             flags,
             code,
             consts,
-            code_data.names,
+            names,
             code_data.varnames,
             code_data.filename,
             code_data.name,

--- a/code_data/__init__.py
+++ b/code_data/__init__.py
@@ -219,10 +219,10 @@ def from_code_constant(value: ConstantDataType) -> object:
 
 
 @dataclass(frozen=True)
-class ConstantTuple:
+class ConstantTuple(DataclassHideDefault):
     tuple: Tuple[ConstantDataType, ...] = field(metadata={"positional": True})
 
 
 @dataclass(frozen=True)
-class ConstantSet:
+class ConstantSet(DataclassHideDefault):
     frozenset: FrozenSet[ConstantDataType] = field(metadata={"positional": True})

--- a/code_data/__init__.py
+++ b/code_data/__init__.py
@@ -69,9 +69,6 @@ class CodeData(DataclassHideDefault):
     # All code objects are recursively transformed to CodeData objects
     consts: Tuple["ConstantDataType", ...] = field(default=(None,))
 
-    # tuple of names of local variables
-    names: Tuple[str, ...] = field(default=tuple())
-
     # tuple of names of arguments and local variables
     varnames: Tuple[str, ...] = field(default=tuple())
 
@@ -104,7 +101,7 @@ def to_code_data(code: CodeType) -> CodeData:
     line_mapping = to_line_mapping(code)
     first_line_number_override = line_mapping.set_first_line(code.co_firstlineno)
     # retrieve the blocks and pop off used line mapping
-    blocks = bytes_to_blocks(code.co_code, line_mapping)
+    blocks = bytes_to_blocks(code.co_code, line_mapping, code.co_names)
     return CodeData(
         blocks,
         line_mapping,
@@ -116,7 +113,6 @@ def to_code_data(code: CodeType) -> CodeData:
         code.co_stacksize,
         to_flags_data(code.co_flags),
         tuple(map(to_code_constant, code.co_consts)),
-        code.co_names,
         code.co_varnames,
         code.co_filename,
         code.co_name,
@@ -133,7 +129,7 @@ def from_code_data(code_data: CodeData) -> CodeType:
     """
     consts = tuple(map(from_code_constant, code_data.consts))
     flags = from_flags_data(code_data.flags)
-    code, line_mapping = blocks_to_bytes(code_data.blocks)
+    code, line_mapping, names = blocks_to_bytes(code_data.blocks)
 
     line_mapping.update(code_data.additional_line_mapping)
     first_line_no = line_mapping.trim_first_line(code_data.first_line_number_override)
@@ -151,7 +147,7 @@ def from_code_data(code_data: CodeData) -> CodeType:
             flags,
             code,
             consts,
-            code_data.names,
+            names,
             code_data.varnames,
             code_data.filename,
             code_data.name,

--- a/code_data/blocks.py
+++ b/code_data/blocks.py
@@ -92,8 +92,8 @@ def blocks_to_bytes(blocks: Blocks) -> Tuple[bytes, LineMapping, tuple[str, ...]
 
     # List of names we have collected from the instructions
     names: list[str] = []
-    # name positions to swap at the end
-    swap_names: list[tuple[int, int]] = []
+    # Mapping of name index to final name positions
+    name_final_positions: dict[int, int] = {}
 
     # Iterate through all blocks and change jump instructions to offsets
     while changed_instruction_lengths:
@@ -106,7 +106,7 @@ def blocks_to_bytes(blocks: Blocks) -> Tuple[bytes, LineMapping, tuple[str, ...]
                 if (block_index, instruction_index) in args:
                     arg_value = args[block_index, instruction_index]
                 else:
-                    arg_value = from_arg(instruction.arg, names, swap_names)
+                    arg_value = from_arg(instruction.arg, names, name_final_positions)
                     args[block_index, instruction_index] = arg_value
                 n_instructions = instruction.n_args_override or _instrsize(arg_value)
                 current_instruction_offset += n_instructions
@@ -141,10 +141,10 @@ def blocks_to_bytes(blocks: Blocks) -> Tuple[bytes, LineMapping, tuple[str, ...]
                     ):
                         changed_instruction_lengths = True
                     args[block_index, instruction_index] = new_arg_value
-
-    # Swap the names we need to
-    for i, j in swap_names:
-        names[i], names[j] = names[j], names[i]
+    # Sort positions by final position
+    names = [
+        names[i] for _, i in sorted(name_final_positions.items(), key=lambda x: x[0])
+    ]
 
     # Finally go assemble the bytes and the line mapping
     bytes_: list[int] = []
@@ -194,7 +194,7 @@ def to_arg(
     return arg
 
 
-def from_arg(arg: Arg, names: list[str], swap_names: list[tuple[int, int]]) -> int:
+def from_arg(arg: Arg, names: list[str], name_final_positions: dict[int, int]) -> int:
     # Use 1 as the arg_value, which will be update later
     if isinstance(arg, Jump):
         return 1
@@ -202,11 +202,9 @@ def from_arg(arg: Arg, names: list[str], swap_names: list[tuple[int, int]]) -> i
         if arg.name not in names:
             names.append(arg.name)
         index = names.index(arg.name)
-        index_override = arg.index_override
-        if index_override is None:
-            return index
-        swap_names.append((index, index_override))
-        return index_override
+        final_index = index if arg.index_override is None else arg.index_override
+        name_final_positions[final_index] = index
+        return final_index
     return arg
 
 

--- a/code_data/blocks.py
+++ b/code_data/blocks.py
@@ -18,7 +18,7 @@ from .dataclass_hide_default import DataclassHideDefault
 
 def bytes_to_blocks(
     b: bytes, line_mapping: LineMapping, names: tuple[str, ...]
-) -> Blocks:
+) -> tuple[Blocks, tuple[str, ...]]:
     """
     Parse a sequence of bytes as a sequence of blocks of instructions.
     """
@@ -78,7 +78,7 @@ def bytes_to_blocks(
             instruction.arg.target = targets.index(instruction.arg.target)
         block.append(instruction)
 
-    return {i: block for i, block in enumerate(blocks)}
+    return {i: block for i, block in enumerate(blocks)}, names[len(found_names) :]
 
 
 def blocks_to_bytes(blocks: Blocks) -> Tuple[bytes, LineMapping, tuple[str, ...]]:

--- a/code_data/test_minimized/sphinx.ext.autodoc.importer.py
+++ b/code_data/test_minimized/sphinx.ext.autodoc.importer.py
@@ -1,7 +1,3 @@
 if False:
-    # For type annotation
-    from typing import Type  # NOQA
-
-    from sphinx.ext.autodoc import ObjectMember
-
-logger = logging.getLogger(__name__)
+    x = None
+logger = None

--- a/code_data/test_minimized/sphinx.ext.autodoc.importer.py
+++ b/code_data/test_minimized/sphinx.ext.autodoc.importer.py
@@ -1,0 +1,7 @@
+if False:
+    # For type annotation
+    from typing import Type  # NOQA
+
+    from sphinx.ext.autodoc import ObjectMember
+
+logger = logging.getLogger(__name__)

--- a/code_data/test_minimized/virtualenv.util.path._pathlib.py
+++ b/code_data/test_minimized/virtualenv.util.path._pathlib.py
@@ -1,0 +1,11 @@
+if six.PY3:
+    from pathlib import Path
+else:
+    if sys.platform == "win32":
+        # workaround for https://github.com/mcmtroffaes/pathlib2/issues/56
+        from .via_os_path import Path
+    else:
+        from pathlib2 import Path
+
+
+__all__ = ("Path",)

--- a/code_data/test_minimized/zmq.tests.test_ioloop.py
+++ b/code_data/test_minimized/zmq.tests.test_ioloop.py
@@ -1,0 +1,4 @@
+def printer():
+    os.system("say hello")
+    raise Exception
+    print(time.time())


### PR DESCRIPTION
Adds support for special casing arguments. Start with the list in https://github.com/python/cpython/blob/abf5f5c5d7071c5dd5a3cfd8fd1989af8df4cd6d/Lib/opcode.py#L26-L33

Then we can also special case any other args which are not ints.

- [x] Names
- [ ] constants
- [ ] locals
- [ ] compare
- [ ] Free