### PR TITLE
Always store line number

### DIFF
--- a/code_data/__init__.py
+++ b/code_data/__init__.py
@@ -42,14 +42,31 @@ class CodeData(DataclassHideDefault):
     # Bytecode instructions
     blocks: Blocks = field(metadata={"positional": True})
 
+    # name of file in which this code object was created
+    filename: str
+
+    # the first line number of the code object
+    first_line_number: int
+
+    # name with which this code object was defined
+    name: str
+
+    # virtual machine stack space required
+    stacksize: int
+
+    # The type of block this is
+    type: BlockType = field(default=None)
+
+    # tuple of names of free variables (referenced via a function’s closure)
+    freevars: tuple[str, ...] = field(default=())
+
+    # code flags
+    flags: FlagsData = field(default_factory=frozenset)
+
     # On Python < 3.10 sometimes there is a line mapping for an additional line
     # for the bytecode after the last one in the code, for an instruction which was
     # compiled away. Include this so we can represent the line mapping faithfully.
     _additional_line: Optional[AdditionalLine] = field(default=None)
-
-    # The first line number to use for the bytecode, if it doesn't match
-    # the first line number in the line table.
-    _first_line_number_override: Optional[int] = field(default=None)
 
     # Additional names to include, which do not appear in any instructions,
     # Mapping of index in the names list to the name
@@ -62,24 +79,6 @@ class CodeData(DataclassHideDefault):
     # Additional constants to include, which do not appear in any instructions,
     # Mapping of index in the names list to the name
     _additional_constants: AdditionalConstants = field(default=tuple())
-
-    # The type of block this is
-    type: BlockType = field(default=None)
-
-    # tuple of names of free variables (referenced via a function’s closure)
-    freevars: tuple[str, ...] = field(default=())
-
-    # virtual machine stack space required
-    stacksize: int = field(default=1)
-
-    # code flags
-    flags: FlagsData = field(default_factory=frozenset)
-
-    # name of file in which this code object was created
-    filename: str = field(default="<string>")
-
-    # name with which this code object was defined
-    name: str = field(default="<module>")
 
     @classmethod
     def from_code(cls, code: CodeType) -> CodeData:

--- a/code_data/line_mapping.py
+++ b/code_data/line_mapping.py
@@ -119,41 +119,7 @@ class LineMapping:
             additional_line.additional_offsets
         )
 
-    def set_first_line(self, first_line: int) -> Optional[int]:
-        """
-        Increments all the line numbers by the first line numbers.
-
-        This should be isomorphic with `trim_first_line`, so that calling them
-        in sequence should be a no-op:
-
-            optional_first_line = cd.set_first_line(x)
-            cd.trim_first_line(optional_first_line)
-        """
-        self._modify_line_offsets(first_line)
-        # If the first line is equal to the min line number now,
-        # we don't need to save it for later, because we can compute it
-        if self._min_line_number() == first_line:
-            return None
-        # Otherwise return it to save when trimming
-        return first_line
-
-    def trim_first_line(self, first_line_number: Optional[int]) -> int:
-        """
-        Offsets all the lines by a constant amount, returning that amount.
-        """
-        trim_amount = first_line_number or self._min_line_number() or 1
-        self._modify_line_offsets(-trim_amount)
-        return trim_amount
-
-    def _min_line_number(self) -> Optional[int]:
-        """
-        Return the minimum line number in the mapping.
-        """
-        return min(
-            (v for v in self.offset_to_line.values() if v is not None), default=None
-        )
-
-    def _modify_line_offsets(self, line_offset: int) -> None:
+    def modify_line_offsets(self, line_offset: int) -> None:
         """
         Modify all the line offsets by a constant amount.
         """

--- a/code_data/normalize.py
+++ b/code_data/normalize.py
@@ -20,7 +20,6 @@ def normalize(x: T) -> T:
                 _additional_names=tuple(),
                 _additional_varnames=tuple(),
                 _additional_line=None,
-                _first_line_number_override=None,
             ),
         )
     if isinstance(x, Instruction):


### PR DESCRIPTION
We always need the line number, not just for the source mapping of each instruciton but also to know where the code block starts.

Closes https://github.com/metadsl/python-code-data/issues/54